### PR TITLE
feat: add listing a dashboard's related analysis and fix imports

### DIFF
--- a/account/dashboards.js
+++ b/account/dashboards.js
@@ -276,6 +276,20 @@ class Dashboards {
     return request(options);
   }
 
+    /** Get list of analysis related with a dashboard
+    * @param  {String} dashboard id
+    * @return {Promise}
+     */
+    listAnalysisRelated(dashboard_id) {
+      const url = `${config.api_url}/dashboard/${dashboard_id}/analysis`;
+      const method = 'GET';
+
+      console.log('URL IS', url);
+
+      const options = { ...this.default_options, url, method };
+      return request(options);
+    }
+
   /**
    * Runs an analysis located in a widget's header button.
    * @param {String} analysis_id The id of the analysis to run.

--- a/account/integrations.connectors.js
+++ b/account/integrations.connectors.js
@@ -1,7 +1,7 @@
-const request          = require('tago/comum/tago_request');
-const paramsSerializer = require('tago/comum/paramsSerializer');
-const config           = require('tago/config');
-const default_headers  = require('tago/comum/default_headers');
+const request          = require('../comum/tago_request');
+const paramsSerializer = require('../comum/paramsSerializer');
+const config           = require('../config');
+const default_headers  = require('../comum/default_headers');
 
 class Connector {
   constructor(acc_token) {

--- a/account/integrations.js
+++ b/account/integrations.js
@@ -1,4 +1,4 @@
-const default_headers  = require('tago/comum/default_headers');
+const default_headers  = require('../comum/default_headers');
 const Connectors       = require('./integrations.connectors.js');
 const Networks         = require('./integrations.networks.js');
 

--- a/account/integrations.networks.js
+++ b/account/integrations.networks.js
@@ -1,7 +1,7 @@
-const request          = require('tago/comum/tago_request');
-const paramsSerializer = require('tago/comum/paramsSerializer');
-const config           = require('tago/config');
-const default_headers  = require('tago/comum/default_headers');
+const request          = require('../comum/tago_request');
+const paramsSerializer = require('../comum/paramsSerializer');
+const config           = require('../config');
+const default_headers  = require('../comum/default_headers');
 
 class Network {
   constructor(acc_token) {


### PR DESCRIPTION
This PR adds the functionality to fetch the related analysis of a dashboard from the API, and also fixes some imports that did not use relative path when they should.